### PR TITLE
yt-dlp周りの最適化他

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from tkinter import ttk, filedialog, messagebox
 import threading
 import queue
 import json
-# import os
+from os import cpu_count
 import sys
 import re
 from pathlib import Path
@@ -366,6 +366,10 @@ class App(tk.Tk):
                 "ignoreerrors": True,
                 "noplaylist": True,
                 "extract_flat": True,
+                # "sleep_interval_requests": .75,
+                # "sleep_interval": 10,
+                # "max_sleep_interval": 20,
+                # "sleep_interval_subtitles": 5,
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 info = ydl.extract_info(url, download=False)
@@ -458,7 +462,7 @@ class App(tk.Tk):
                     "message": f"「{item['title']}」のダウンロード中にエラーが発生しました。\n\n詳細: {clean_message}",
                 }
                 self.comm_queue.put(("error", error_details))
-                raise e
+                # raise e
         self.comm_queue.put(("download_finished", None))
 
     def _process_single_download(self, item):
@@ -490,7 +494,13 @@ class App(tk.Tk):
             "noplaylist": True,
             "progress_hooks": [self.progress_hook],
             "final_ext": ext,
+            # "sleep_interval_requests": .75,
+            # "sleep_interval": 10,
+            # "max_sleep_interval": 20,
+            # "sleep_interval_subtitles": 5,
+            "concurrent_fragment_downloads": cpu_count() or 1,
             "ffmpeg_location": str(RESOURCE_PATH / "ffmpeg" / "ffmpeg.exe"),
+            "extractor_args": {"youtube": {"formats": ["dashy"]}},
         }
 
         audio_format_map = {

--- a/main.py
+++ b/main.py
@@ -105,19 +105,19 @@ class App(tk.Tk):
         # --- 定期的なキューのチェック ---
         self.after(100, self.process_comm_queue)
 
-    def _is_valid_url(self, url):
-        if not url:
-            return False
-        regex = re.compile(
-            r"^(?:http|ftp)s?://"
-            r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"
-            r"localhost|"
-            r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"
-            r"(?::\d+)?"
-            r"(?:/?|[/?]\S+)$",
-            re.IGNORECASE,
-        )
-        return re.match(regex, url) is not None
+    # def _is_valid_url(self, url):
+    #     if not url:
+    #         return False
+    #     regex = re.compile(
+    #         r"^(?:http|ftp)s?://"
+    #         r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"
+    #         r"localhost|"
+    #         r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"
+    #         r"(?::\d+)?"
+    #         r"(?:/?|[/?]\S+)$",
+    #         re.IGNORECASE,
+    #     )
+    #     return re.match(regex, url) is not None
 
     def _load_icons(self):
         base_icon_theme = "white" if self.current_theme == "dark" else "black"
@@ -350,12 +350,12 @@ class App(tk.Tk):
 
     def add_to_queue(self):
         url = self.url_entry.get().strip()
-        if not self._is_valid_url(url):
-            messagebox.showwarning(
-                "無効なURL",
-                "有効なURL形式ではありません。\nURLを正しく入力または貼り付けしてください。",
-            )
-            return
+        # if not self._is_valid_url(url):
+        #     messagebox.showwarning(
+        #         "無効なURL",
+        #         "有効なURL形式ではありません。\nURLを正しく入力または貼り付けしてください。",
+        #     )
+        #     return
         self.update_status(f"情報を取得中: {url}")
         self.add_queue_button.config(state="disabled")
         thread = threading.Thread(target=self._get_video_info_thread, args=(url,))


### PR DESCRIPTION
yt-dlpのベストプラクティスを幾つか搔い摘みました｡
プルダウンの選択肢とかも変更してるので適宜微調整の程､宜しく御願いします｡
- URL確認撤廃
  yt-dlpはURL以外も受け付ける
  - 動画ID単体 e.g. `x438S0afLM0`
  - 接頭辞によるクエリ e.g. `ytsearch:harukun19 音mad`
- "entries"抽出の再帰化
  再生リストがネストしている時に発生した`KeyError: 'url'`を修正
  e.g. `https://youtube.com/@harukun19`
- `ydl_opts`改善
  yt-dlpの引数を概ね適正化
- クエリ削減
  キュー追加時の`info`を再利用
- リファクタリング：pathlibに統一
- ダウンロード高速化
  取り敢えずプロセッサ数だけ並列化